### PR TITLE
Allow custom models

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,33 @@ Mongoose models can be found in `models` directory. To add a new model use the s
 
 To connect to mongo
 
+
 ```javascript
-Connector.connect('mongodb://mongoUriGoseHere:27017/db', {})
-  .then(function(db) {
-    // has connection object
+
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var customSchemas = {
+    //The key is the same as the datasetId (e.g. workorders)
+    workorders: function(mongooseConnection) {
+        var customWorkorderSchema = new Schema({
+            ...
+            name: {type: String}
+            ...
+        },  {timestamps: true});
+        
+        mongooseConnection.model('CustomWorkorderModel', customWorkorderSchema);
+    }
+    ... 
+    //Any other custom schemas
+    ...
+};
+
+Connector.connect('mongodb://mongoUriGoseHere:27017/db', {}, customSchemas)
+  .then(function() {
+    // connected successfully
   }, function(error) {
-    // handle error
+    // An error occurred when connecting
   });
 ```
 
@@ -35,9 +56,12 @@ Connector.connect('mongodb://mongoUriGoseHere:27017/db', {})
 Get the Data access layer object for a collection/dataset.
 
 ```javascript
-Connector.getDataAccessLayer(collectionName, Model).
+
+var datasetId = "workorders";
+
+Connector.getDAL(datasetId).
   then(function(_dal) {
-    // do stuff with collection dal
+    // do stuff with dataset dal
   }, function(error) {
     // handle error
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var connector = require('./connector');
 var Promise = require('bluebird');
 var Store = require('./mongoose-store');
 var label = require('./config').module;
+var _ = require('lodash');
 
 var MODELS = {};
 
@@ -15,11 +16,25 @@ function _handleError(error) {
   return Promise.reject(error);
 }
 
-function connect(uri, opts) {
+/**
+ *
+ * Function to connect to mongoose and set up models based on schemas.
+ *
+ * Users have the option to set their own custom schemas if required.
+ *
+ * @param {string} mongoUrl - A valid mongodb connection URL
+ * @param {object} options - Any custom connection parameters for the mongoose connection
+ * @param {object} [customSchemas] - Optional Custom schemas passed by the application.
+ * @returns {bluebird|exports|module.exports}
+ */
+function connect(mongoUrl, options, customSchemas) {
+
+  //The default dataset schemas to use will be the ones passed by the user
+  var schemasToUse = _.defaults(customSchemas, modelSchemas);
+
   return new Promise(function(resolve) {
-    connector.connectToMongo(uri, opts).then(function(db) {
-      Object.keys(modelSchemas).forEach(function(key) {
-        var schema = modelSchemas[key];
+    connector.connectToMongo(mongoUrl, options).then(function(db) {
+      _.each(schemasToUse, function(schema, key) {
         _addCollection(key, schema, db);
       });
       resolve(true);
@@ -39,12 +54,13 @@ function getDataAccessLayer(dataset) {
   return new Promise(function(resolve, reject) {
     var model = MODELS[dataset];
     if (!model) {
-      return reject(new Error("Invalid model for dataset" + dataset));
+      return reject(new Error("Invalid model for dataset " + dataset));
     }
     var mongooseDal = new Store(dataset, model);
     resolve(mongooseDal);
   });
 }
+
 
 module.exports = {
   getDAL: getDataAccessLayer,

--- a/models/index.js
+++ b/models/index.js
@@ -1,6 +1,6 @@
-'use strict';
-
-// TODO move to the modules
+//'use strict';
+//
+//// TODO move to the modules
 module.exports = {
   messages: require('./messages'),
   gps: require('./gps'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mongoose-store",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Direct mongoose storage",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
# Motivation

There are scenarios where developers want to use their own mongoose models for `datasets`.

This change allows the developer to pass their own mongoose models when initialising the mongoose store.