### PR TITLE
Allowing custom CRUDL functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,49 @@ Connector.getDAL(datasetId).
   });
 ```
 
+#### listen
+
+The Data Access Layer object for a collection has a `listen` function that ensures that the CRUDL topics for the data set are subscribed.
+
+```javascript
+
+/**
+* This function has access to the mongoose Model associated with the data set
+* through the "model" property
+*
+* @returns {Promise}
+*/
+function customListFunction() {
+  return this.model.list();
+}
+
+
+var datasetId = "workorders";
+
+Connector.getDAL(datasetId).
+  then(function(_dal) {
+    
+    //This function will subscribe to the CRUDL topics for "workorders"
+    //The "list" topic will execute the "customListFunction"
+    //Note: This function will only overrdie the "list" topic for a single data set.
+    _dal.listen(":data", mediator, {
+        list: customListFunction
+    });
+    
+  }, function(error) {
+    // handle error
+  });
+
+```
+
+The following functions are overridable:
+
+- create
+- update
+- list
+- remove
+- read
+
 #### disconnect
 
 ```javascript
@@ -79,3 +122,5 @@ Connector.disconnect()
     // something went wrong
   });
 ```
+
+

--- a/lib/listen.js
+++ b/lib/listen.js
@@ -1,28 +1,81 @@
 'use strict';
 var Topics = require('fh-wfm-mediator/lib/topics');
+var _ = require('lodash');
+
+
+/**
+ *
+ * Creating a new object to be saved as a mongoose document
+ *
+ * @param objectToCreate
+ */
+function create(objectToCreate) {
+  var self = this;
+  // needs a custom function because the created id is different
+  // than the one in the request() topic
+  var uid = objectToCreate.id;
+
+  self.create(objectToCreate).then(function(createdObject) {
+    self.mediator.publish([self.topics.getTopic('create', 'done'), uid].join(':'), createdObject);
+  }).catch(function(err) {
+    self.mediator.publish([self.topics.getTopic('create', 'error'), uid].join(':'), err);
+  });
+}
 
 module.exports = function decorate(Class) {
-  Class.prototype.listen = function(topicPrefix, mediator) {
+
+  /**
+   *
+   * Registering subscribers for CRUDL topics a single data set.
+   *
+   * The `customFunctions` parameter allows overriding any of the CRUDL functions
+   *
+   * E.g.
+   *
+   * {
+   *   ...
+   *   list: function customListFunction() {}
+   *   ...
+   * }
+   *
+   * @param {string} topicPrefix
+   * @param {Mediator} mediator
+   * @param {object} [customFunctions] - Optional overrides for the dataset functions function
+   */
+  Class.prototype.listen = function(topicPrefix, mediator, customFunctions) {
+    customFunctions = customFunctions || {};
+
     var self = this;
+
+    //Applying any custom crudl functions
+    var crudlFunctions = _.defaults(customFunctions, {
+      read: self.read,
+      update: self.update,
+      remove: self.remove,
+      list: self.list,
+      create: create
+    });
+
+    //Binding the crudl functions to the Store class.
+    //This will give them access to the `model` property to perform queries etc.
+    crudlFunctions = _.mapValues(crudlFunctions, function(crudlFunction, functionName) {
+      if (!_.isFunction(crudlFunction)) {
+        throw new Error("Expected a function for custom function " + functionName + " but got " + typeof crudlFunction);
+      }
+
+      return _.bind(crudlFunction, self);
+    });
+
     this.topics = new Topics(mediator);
     this.mediator = mediator;
     this.topics
       .prefix('wfm' + topicPrefix)
       .entity(self.datasetId)
-      .on('create', function(object) {
-        // needs a custom function because the created id is different
-        // than the one in the request() topic
-        var uid = object.id;
-        self.create(object).then(function(createdObject) {
-          self.mediator.publish([self.topics.getTopic('create', 'done'), uid].join(':'), createdObject);
-        }).catch(function(err) {
-          self.mediator.publish([self.topics.getTopic('create', 'error'), uid].join(':'), err);
-        });
-      })
-      .on('read', self.read.bind(self))
-      .on('update', self.update.bind(self))
-      .on('delete', self.remove.bind(self))
-      .on('list', self.list.bind(self));
+      .on('create', crudlFunctions.create)
+      .on('read', crudlFunctions.read)
+      .on('update', crudlFunctions.update)
+      .on('delete', crudlFunctions.remove)
+      .on('list', crudlFunctions.list);
 
     console.log('listening for: ', this.topics.getTopic());
   };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "grunt-eslint": "19.0.0",
     "grunt-shell": "2.1.0",
     "load-grunt-tasks": "3.5.2",
-    "mocha": "3.2.0"
+    "mocha": "3.2.0",
+    "sinon": "^1.17.7",
+    "sinon-as-promised": "^4.0.2"
   },
   "dependencies": {
     "bluebird": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mongoose-store",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Direct mongoose storage",
   "main": "./lib/index.js",
   "scripts": {

--- a/test/listen-spec.js
+++ b/test/listen-spec.js
@@ -1,0 +1,80 @@
+var mediator = require('fh-wfm-mediator/lib/mediator');
+var sinon = require('sinon');
+require('sinon-as-promised');
+var decorate = require('../lib/listen');
+var _ = require('lodash');
+
+describe("Mongoose Store Listen", function() {
+
+  var stubs = {
+    read: sinon.spy(),
+    update: sinon.spy(),
+    remove: sinon.spy(),
+    list: sinon.stub().resolves([]),
+    create: sinon.spy()
+  };
+
+  var mockStore;
+
+  var listTopic = "wfm:mockdatasetid:list";
+  var doneListTopic = "done:wfm:mockdatasetid:list";
+
+  function MockStore(datasetId, model) {
+    this.datasetId = datasetId;
+    this.model = model;
+  }
+
+  MockStore.prototype.list = stubs.list;
+  MockStore.prototype.read = stubs.read;
+  MockStore.prototype.update = stubs.update;
+  MockStore.prototype.create = stubs.create;
+  MockStore.prototype.remove = stubs.remove;
+
+  beforeEach(function() {
+    _.each(stubs, function(stub) {
+      stub.reset();
+    });
+  });
+
+  afterEach(function() {
+    mockStore.topics.unsubscribeAll();
+  });
+
+  it("should use default CRUDL functions for subscribers", function() {
+
+    decorate(MockStore);
+
+    mockStore = new MockStore("mockdatasetid");
+
+    mockStore.listen("", mediator);
+
+    var donePromise = mediator.promise(doneListTopic);
+
+    mediator.publish(listTopic);
+
+    return donePromise.then(function() {
+      sinon.assert.calledOnce(stubs.list);
+    });
+  });
+
+  it("should allow for custom functions", function() {
+
+    var customFunctions = {
+      list: sinon.stub().resolves([])
+    };
+
+    mockStore = new MockStore("mockdatasetid");
+
+    mockStore.listen("", mediator, customFunctions);
+
+    var donePromise = mediator.promise(doneListTopic);
+
+    mediator.publish(listTopic);
+
+    return donePromise.then(function() {
+      sinon.assert.calledOnce(customFunctions.list);
+      sinon.assert.notCalled(stubs.list);
+    });
+  });
+
+});


### PR DESCRIPTION
# Motivation

Developers may wish to have custom handlers for their Data Access using mongoose.

This change allows custom functions to override the default CRUDL topics for a single data set.