### PR TITLE
Raincatch 756 return error for no document found

### DIFF
--- a/lib/mongoose-store.js
+++ b/lib/mongoose-store.js
@@ -15,6 +15,36 @@ function convertToJSON(mongooseDocument) {
   return mongooseDocument ? mongooseDocument.toJSON() : undefined;
 }
 
+/**
+ *
+ * Creating an error describing a document that hasn't been found.
+ *
+ * @param {string} id - The ID of the document that wasn't found
+ */
+function createNoDocumentError(id) {
+  var error = new Error("No document with id " + id  + " found");
+  error.id = id;
+  return Promise.reject(error);
+}
+
+/**
+ *
+ * Handling an error response that includes an ID.
+ *
+ * @param {string} id
+ * @param {Error} err
+ */
+function handleError(id, err) {
+
+  if (!(err instanceof Error)) {
+    err = new Error(err);
+  }
+
+  err.id = id;
+
+  return Promise.reject(err);
+}
+
 
 function Store(_datasetId, _model) {
   this.model = _model;
@@ -45,18 +75,29 @@ Store.prototype.findById = function(id) {
 };
 
 Store.prototype.read = function(_id) {
-  return this.model.findOne({id: _id}).exec().then(convertToJSON);
+  return this.model.findOne({id: _id}).exec().then(function(foundDocument) {
+
+    if (!foundDocument) {
+      return createNoDocumentError(_id);
+    }
+
+    return foundDocument;
+  }).then(convertToJSON).catch(function(err) {
+    return handleError(_id, err);
+  });
 };
 
 Store.prototype.update = function(object) {
   return this.model.findOne({id: object.id}).exec().then(function(foundDocument) {
     if (!foundDocument) {
-      return Promise.reject(new Error("No document with id " + object.id  + " found"));
+      return createNoDocumentError(object.id);
     } else {
       _.extend(foundDocument, object);
       return foundDocument.save();
     }
-  }).then(convertToJSON);
+  }).then(convertToJSON).catch(function(err) {
+    return handleError(object.id, err);
+  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mongoose-store",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Direct mongoose storage",
   "main": "./lib/index.js",
   "scripts": {

--- a/test/mongoose-store-spec.js
+++ b/test/mongoose-store-spec.js
@@ -104,8 +104,18 @@ describe(config.module, function() {
     });
   });
 
+  it('should return an error if no record exists', function(done) {
+    var id = "idontexist";
+    testDal.read(id).then(function() {
+      done(new Error("Expected an error"));
+    }, function(error) {
+      assert.ok(error, "Expected an error");
+      done();
+    });
+  });
+
   it('should read test record', function(done) {
-    var id = testDoc._id;
+    var id = testDoc.id;
     testDal.read(id).then(function() {
       done();
     }, function(error) {


### PR DESCRIPTION
Ensuring that when reading a single document, if it is not found then it is an error case.