### PR TITLE
[RAINCATCH-746|WIP] Expose cause of error upon validation fail

### DIFF
--- a/lib/mongoose-store.js
+++ b/lib/mongoose-store.js
@@ -15,6 +15,33 @@ function convertToJSON(mongooseDocument) {
   return mongooseDocument ? mongooseDocument.toJSON() : undefined;
 }
 
+function errorHandler(data, operation) {
+  return function(err) {
+    if(err) {
+      var error = {
+        operation: operation,
+        name: err.name,
+        message: err.message,
+        document: data
+      };
+
+      if(err.errors) {
+        error.cause = {};
+        for(var e in err.errors) {
+          error.cause[e] = {
+            name: err.errors[e].name,
+            msg: err.errors[e].message
+          }
+        }
+      } else {
+        error.cause = err.message;
+      }
+
+      console.error("[ERROR] " + error.operation + ": [" + error.name + "] " + error.message + "\n", error);
+      throw new Error(error.message);
+    }
+  }
+}
 
 function Store(_datasetId, _model) {
   this.model = _model;
@@ -29,7 +56,7 @@ Store.prototype.init = function(data) {
   var self = this;
   return Promise.map(data, function(entry) {
     var record = new self.model(entry);
-    return record.save();
+    return record.save(errorHandler(entry, 'init'));
   });
 };
 
@@ -37,7 +64,7 @@ Store.prototype.isPersistent = true;
 
 Store.prototype.create = function(object) {
   var record = new this.model(object);
-  return record.save();
+  return record.save(errorHandler(entry, 'create'));
 };
 
 Store.prototype.findById = function(id) {
@@ -54,7 +81,7 @@ Store.prototype.update = function(object) {
       return Promise.reject(new Error("No document with id " + object.id  + " found"));
     } else {
       _.extend(foundDocument, object);
-      return foundDocument.save();
+      return foundDocument.save(errorHandler(entry, 'update'));
     }
   }).then(convertToJSON);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mongoose-store",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Direct mongoose storage",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
# What
Currently, mongoose would return a generic error when validation fail occurs with very little detail of what is causing the issue. 

# How
Created an error handler which would log a defined error with the document that is causing the validation error. 

# JIRA
https://issues.jboss.org/browse/RAINCATCH-746
