### PR TITLE
Don't return _id on read and list operations.

### DIFF
--- a/lib/mongoose-store.js
+++ b/lib/mongoose-store.js
@@ -93,14 +93,14 @@ Store.prototype.create = function(object) {
 
 Store.prototype.findById = function(id) {
   var self = this;
-  return this.model.findOne({id: id}).exec().then(convertToJSON).catch(function(err) {
+  return this.model.findOne({id: id}, {_id: 0}).exec().then(convertToJSON).catch(function(err) {
     return self.handleError(id, err);
   });
 };
 
 Store.prototype.read = function(_id) {
   var self = this;
-  return this.model.findOne({id: _id}).exec().then(function(foundDocument) {
+  return this.model.findOne({id: _id}, {_id: 0}).exec().then(function(foundDocument) {
 
     if (!foundDocument) {
       return createNoDocumentError(_id);
@@ -153,7 +153,7 @@ Store.prototype.list = function(filter) {
 
   var query = buildQuery(filter);
 
-  var mongooseQuery = this.model.find(query);
+  var mongooseQuery = this.model.find(query, {_id: 0});
 
   if (filter.sort && typeof filter.sort === 'object') {
     mongooseQuery.sort(filter.sort);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mongoose-store",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Direct mongoose storage",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Sync will not allow _id to be provided in the future and currently
breaks if an ObjectID is provided into the sync code.

This change tells mongoose for find operations to not return
the _id field.