### PR TITLE
Raincatch 786 create nunctions

### DIFF
--- a/lib/listen.js
+++ b/lib/listen.js
@@ -22,6 +22,26 @@ function create(objectToCreate) {
   });
 }
 
+/**
+ *
+ * Updating an existing object saved as a mongoose document
+ *
+ * @param objectToUpdate
+ */
+function update(objectToUpdate) {
+  var self = this;
+
+  //The object being updated may not have had an id parameter set yet
+  //when syncing. So the localuid is used as a query instead
+  var uid = objectToUpdate.id || objectToUpdate._localuid;
+
+  self.update(objectToUpdate).then(function(updatedObject) {
+    self.mediator.publish([self.topics.getTopic('update', 'done'), uid].join(':'), updatedObject);
+  }).catch(function(err) {
+    self.mediator.publish([self.topics.getTopic('update', 'error'), uid].join(':'), err);
+  });
+}
+
 module.exports = function decorate(Class) {
 
   /**
@@ -50,7 +70,7 @@ module.exports = function decorate(Class) {
     //Applying any custom crudl functions
     var crudlFunctions = _.defaults(customFunctions, {
       read: self.read,
-      update: self.update,
+      update: update,
       remove: self.remove,
       list: self.list,
       create: create

--- a/lib/listen.js
+++ b/lib/listen.js
@@ -95,7 +95,23 @@ module.exports = function decorate(Class) {
       .on('read', crudlFunctions.read)
       .on('update', crudlFunctions.update)
       .on('delete', crudlFunctions.remove)
-      .on('list', crudlFunctions.list);
+      .on('list', function(filter) {
+        filter = filter || {};
+        var _self = this;
+
+        //(Optional) Different filters may require topic UIDs.
+        //This can avoid the scenario where list done topics are publised with the
+        //wrong results
+        var topicUid = filter.topicUid;
+
+        filter = _.omit(filter, 'topicUid');
+
+        crudlFunctions.list(filter).then(function(filteredList) {
+          _self.mediator.publish(self.topics.getTopic('list', 'done', topicUid), filteredList);
+        }).catch(function(err) {
+          _self.mediator.publish(self.topics.getTopic('list', 'done', topicUid), err);
+        });
+      });
 
     console.log('listening for: ', this.topics.getTopic());
   };

--- a/lib/mongoose-store.js
+++ b/lib/mongoose-store.js
@@ -117,8 +117,6 @@ Store.prototype.update = function(object) {
 
   var query;
 
-  console.log("*** Update ",object);
-
   if (!_.isObject(object)) {
     return self.handleError(null, new Error("Expected an object to update"));
   }

--- a/lib/mongoose-store.js
+++ b/lib/mongoose-store.js
@@ -93,14 +93,14 @@ Store.prototype.create = function(object) {
 
 Store.prototype.findById = function(id) {
   var self = this;
-  return this.model.findOne({id: id}).exec().then(convertToJSON).catch(function(err) {
+  return this.model.findOne({id: id}, {_id: 0}).exec().then(convertToJSON).catch(function(err) {
     return self.handleError(id, err);
   });
 };
 
 Store.prototype.read = function(_id) {
   var self = this;
-  return this.model.findOne({id: _id}).exec().then(function(foundDocument) {
+  return this.model.findOne({id: _id}, {_id: 0}).exec().then(function(foundDocument) {
 
     if (!foundDocument) {
       return createNoDocumentError(_id);
@@ -153,7 +153,7 @@ Store.prototype.list = function(filter) {
 
   var query = buildQuery(filter);
 
-  var mongooseQuery = this.model.find(query);
+  var mongooseQuery = this.model.find(query, {_id: 0});
 
   if (filter.sort && typeof filter.sort === 'object') {
     mongooseQuery.sort(filter.sort);

--- a/lib/mongoose-store.js
+++ b/lib/mongoose-store.js
@@ -115,15 +115,33 @@ Store.prototype.read = function(_id) {
 Store.prototype.update = function(object) {
   var self = this;
 
-  return this.model.findOne({id: object.id}).exec().then(function(foundDocument) {
+  var query;
+
+  console.log("*** Update ",object);
+
+  if (!_.isObject(object)) {
+    return self.handleError(null, new Error("Expected an object to update"));
+  }
+
+  var uid = object._localuid || object.id;
+
+  if (object.id) {
+    query = {id: object.id};
+  } else if (object._localuid) {
+    query = {_localuid: object._localuid};
+  } else {
+    return self.handleError(null, new Error("Expected the object to have either an id or _localuid field"));
+  }
+
+  return this.model.findOne(query).exec().then(function(foundDocument) {
     if (!foundDocument) {
-      return createNoDocumentError(object.id);
+      return createNoDocumentError(uid);
     } else {
       _.extend(foundDocument, object);
       return foundDocument.save();
     }
   }).then(convertToJSON).catch(function(err) {
-    return self.handleError(object.id, err);
+    return self.handleError(uid, err);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mongoose-store",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Direct mongoose storage",
   "main": "./lib/index.js",
   "scripts": {

--- a/test/mongoose-store-spec.js
+++ b/test/mongoose-store-spec.js
@@ -6,6 +6,7 @@ var Models = require('./../models');
 var Connector = require('./../lib');
 var mongoose = require('mongoose');
 var expect = require('expect');
+var _ = require('lodash');
 
 var mongoUri = 'mongodb://localhost:27017/raincatcher-mongo-connector';
 
@@ -92,7 +93,9 @@ describe(config.module, function() {
 
   it('should add item to result collection', function(done) {
     testDal.create({
+      id: "testid",
       status: 'test',
+      _localuid: "localid",
       workorderId: '1234567890'
     }).then(function(doc) {
       testDoc = doc;
@@ -115,6 +118,15 @@ describe(config.module, function() {
     testDal.update(testDoc).then(function(result) {
       testDoc = result;
       done(assert.equal(result.id, id));
+    }, function(error) {
+      done(error);
+    });
+  });
+
+  it('should update with a local id', function(done) {
+    testDal.update(_.omit(testDoc, 'id')).then(function(result) {
+      testDoc = result;
+      done(assert.equal(result._localuid, 'localid'));
     }, function(error) {
       done(error);
     });


### PR DESCRIPTION
# Changes

Replacing https://github.com/feedhenry-raincatcher/raincatcher-mongoose-store/pull/19

In addition, adding https://github.com/feedhenry-raincatcher/raincatcher-mongoose-store/commit/90191a16fdfc40950f6cc88ac61b15e94d9e38e9 to protect the document update from the scenario where the remote ID has not been applied yet.

This is a workaround from: https://issues.jboss.org/browse/FH-3561